### PR TITLE
Add note about changing incubator-mynewt-core to mynewt-core

### DIFF
--- a/docs/faq/answers.md
+++ b/docs/faq/answers.md
@@ -1,5 +1,5 @@
 ## FAQ
-Here are a list of frequently asked questions. They are grouped by categories.
+Here are some lists, grouped by categories, of frequently asked questions. 
 
 **Mynewt software questions:**
 

--- a/docs/faq/go_env.md
+++ b/docs/faq/go_env.md
@@ -15,7 +15,7 @@ This guide shows you how to perform the following:
 
 
 ### Step 1: Installing Go 
-The latest master branch of newt and newtmgr requires GO version 1.6 or higher. You can skip this step and proceed to Step 2 if you already have Go version 1.6 or higher installed.
+The latest master branch of newt and newtmgr requires GO version 1.7.6 or higher. You can skip this step and proceed to Step 2 if you already have Go version 1.7.6 or higher installed.
 
 <br>
 #### Installing Go on Mac OS X
@@ -42,30 +42,8 @@ You can also download the Go package directly from (https://golang.org/dl/) inst
 
 <br>
 #### Installing Go on Linux
+You can download Go from [https://golang.org/dl/](https://golang.org/dl/).
 
-Use apt-get to install Go: 
-```no-highlight
-$sudo apt-get update
-$sudo apt-get install golang 
-Reading package lists... Done
-Building dependency tree       
-Reading state information... Done
-
-      ...
-
-The following NEW packages will be installed:
-  golang
-0 upgraded, 1 newly installed, 0 to remove and 43 not upgraded.
-Need to get 0 B/2,812 B of archives.
-After this operation, 10.2 kB of additional disk space will be used.
-Selecting previously unselected package golang.
-(Reading database ... 244990 files and directories currently installed.)
-Preparing to unpack .../golang_2%3a1.6.1+1ubuntu2_all.deb ...
-Unpacking golang (2:1.6.1+1ubuntu2) ...
-Setting up golang (2:1.6.1+1ubuntu2) ...
-$ go version
-go version go1.6.3 linux/amd64
-```
 <br>
 ###Step 2: Setting Up Your Go Environment 
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -1,0 +1,24 @@
+## Known Issues
+
+Here is a list of known issues and workarounds:
+
+1. `newt install` returns the following error:
+
+        ReadDesc: No matching branch for apache-mynewt-core repo
+        No matching branch for apache-mynewt-core repo 
+
+    If you installed a binary version of newt 1.0 or built newt from source using Go version 1.7.5 or earlier, you might see this error because the apache-mynewt-core Git repository location changed due to Mynewt's graduation from an incubator project to an Apache top level project. Go does not support HTTP redirect in Go versions 1.7.5 or earlier.  You can use one of the following workarounds:
+
+       **Workaround 1:** Edit the `project.yml` file and change the line `repo: incubator-mynewt-core` as shown in the following example to `repo: mynewt-core`:
+
+            repository.apache-mynewt-core:
+                type: github
+                vers: 1-latest
+       	        user: apache
+                repo: incubator-mynewt-core
+
+       **Workaround 2:** If you are buiding newt from source, use Go version 1.7.6 or higher to build newt. You can download Go from [https://golang.org/dl/](https://golang.org/dl/).
+ 
+      
+
+

--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -127,26 +127,9 @@ If you are running Linux on a different architecture, you can install the Debian
 **Note**: Newt version 1.0.0 has been tested on Linux amd64 platforms. Version 1.0.0 does not build on 32 bit platforms but have been fixed for the next release.
 
 <br>
-#### Installing Go 1.7 
+#### Installing Go 
 
-You need Go version 1.7 or higher to build Newt version 1.0.0.  Currently, the latest Go version that Ubuntu installs is 1.6.  Run `go version` to check if you have Go 1.7 installed. 
-
-<br>
-
-Install Go version 1.7:
-
-```no-highlight
-$sudo apt-get install golang-1.7-go
-Reading package lists... Done
-     ...
-Unpacking golang-1.7-go (1.7.1-2ubuntu1) ...
-Setting up golang-1.7-go (1.7.1-2ubuntu1) ...
-$
-$sudo ln -sf ../lib/go-1.7/bin/go /usr/bin/go
-$go version
-go version go1.7.1 linux/amd64
-```
-You can also download version 1.7 from [https://golang.org/dl/](https://golang.org/dl/). 
+You need Go version 1.7.6 or higher to build Newt version 1.0.0.  Currently, the latest Go version that Ubuntu installs is 1.6.  Run `go version` to check if you have Go 1.7.6 installed. You can download Go from [https://golang.org/dl/](https://golang.org/dl/).
 
 <br>
 #### Installing from the Source Package

--- a/docs/newt/install/newt_windows.md
+++ b/docs/newt/install/newt_windows.md
@@ -53,7 +53,7 @@ Download and install [Git for Windows](https://git-for-windows.github.io) if it 
 
 
 ### Step 3: Installing Go 
-Download and install the latest version of [Go](https://golang.org/dl/). Newt requires Go version 1.7 or higher.
+Download and install the latest version of [Go](https://golang.org/dl/). Newt requires Go version 1.7.6 or higher.
 
 ###Step 4: Setting Up Your Go Environment 
 

--- a/docs/newtmgr/install_linux.md
+++ b/docs/newtmgr/install_linux.md
@@ -131,26 +131,9 @@ If you are running Linux on a different architecture, you can install the Debian
 **Note**: Newtmgr version 1.0.0 has been tested on Linux amd64 platforms. 
 
 <br>
-#### Installing Go 1.7 
+#### Installing Go
 
-You need Go version 1.7 or higher to build Newtmgr version 1.0.0.  Currently, the latest Go version that Ubuntu installs is 1.6.  Run `go version` to check if you have Go 1.7 installed. 
-
-<br>
-
-Install Go version 1.7:
-
-```no-highlight
-$sudo apt-get install golang-1.7-go
-Reading package lists... Done
-     ...
-Unpacking golang-1.7-go (1.7.1-2ubuntu1) ...
-Setting up golang-1.7-go (1.7.1-2ubuntu1) ...
-$
-$sudo ln -sf ../lib/go-1.7/bin/go /usr/bin/go
-$go version
-go version go1.7.1 linux/amd64
-```
-You can also download version 1.7 from [https://golang.org/dl/](https://golang.org/dl/). 
+You need Go version 1.7.6 or higher to build Newtmgr version 1.0.0.  Currently, the latest Go version that Ubuntu installs is 1.6.  Run `go version` to check if you have Go 1.7.6 installed. You can download Go from [https://golang.org/dl/](https://golang.org/dl/).
 
 <br>
 #### Installing from the Source Package

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -7,8 +7,24 @@ This page shows you how to create a Mynewt project using the `newt` command-line
 This guide shows you how to:
 
 1. Create a new project and fetch the source repository and dependecies.
-2. Test the project packages (Not supported on Windows).
-3. Build and run the simulated blinky application (Not supported on Windows). 
+2. Test the project packages. (Not supported on Windows.)
+3. Build and run the simulated blinky application. (Not supported on Windows.) 
+
+**Note:** The apache-mynewt-core Git repository location has changed due to Mynewt's graduation from an incubator project to an Apache top level project. If you installed a binary version of newt 1.0 or built newt from source using Go version 1.7.5 or earlier, you will get the following error when you run the `newt install` step in this tutorial: 
+
+```no-highlight
+ReadDesc: No matching branch for apache-mynewt-core repo
+Error: No matching branch for apache-mynewt-core repo
+```
+To avoid this error, you must edit the `project.yml` file and change the line `repo: incubator-mynewt-core` to `repo: mynewt-core`:
+<br>
+```hl_lines="5"
+repository.apache-mynewt-core:
+    type: github
+    vers: 1-latest
+    user: apache
+    repo: incubator-mynewt-core
+```
 
 <br>
 
@@ -98,7 +114,7 @@ repository.apache-mynewt-core:
     type: github
     vers: 1-latest
     user: apache
-    repo: incubator-mynewt-core
+    repo: mynewt-core
 ```
 
 Changing vers to 0-dev will put you on the latest master branch. **This branch may not be stable and you may encounter bugs or other problems.**
@@ -112,8 +128,23 @@ Run the `newt install` command, from your project base directory (myproj), to fe
 $ newt install
 apache-mynewt-core
 ```
-
 **Note:** It may take a while to download the apache-mynewt-core reposistory.  Use the _-v_ (verbose) option to see the installation progress.
+<br>
+
+**Note:** If you get the following error: 
+```no-highlight
+ReadDesc: No matching branch for apache-mynewt-core repo
+Error: No matching branch for apache-mynewt-core repo
+```
+You must edit the `project.yml` file and change the line `repo: incubator-mynewt-core` to `repo: mynewt-core` as mentioned at the beginning of this tutorial:
+<br>
+```hl_lines="5"
+repository.apache-mynewt-core:
+    type: github
+    vers: 1-latest
+    user: apache
+    repo: incubator-mynewt-core
+```
 
 <br>
 

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -16,7 +16,7 @@ This guide shows you how to:
 ReadDesc: No matching branch for apache-mynewt-core repo
 Error: No matching branch for apache-mynewt-core repo
 ```
-To avoid this error, you must edit the `project.yml` file and change the line `repo: incubator-mynewt-core` to `repo: mynewt-core`:
+To avoid this error, you must edit the `project.yml` file and change the line `repo: incubator-mynewt-core` as shown in the following example to `repo: mynewt-core`:
 <br>
 ```hl_lines="5"
 repository.apache-mynewt-core:
@@ -131,20 +131,12 @@ apache-mynewt-core
 **Note:** It may take a while to download the apache-mynewt-core reposistory.  Use the _-v_ (verbose) option to see the installation progress.
 <br>
 
-**Note:** If you get the following error: 
+**Note:** As mentioned in the beginning of this tutorial, if you get the following error: 
 ```no-highlight
 ReadDesc: No matching branch for apache-mynewt-core repo
 Error: No matching branch for apache-mynewt-core repo
 ```
-You must edit the `project.yml` file and change the line `repo: incubator-mynewt-core` to `repo: mynewt-core` as mentioned at the beginning of this tutorial:
-<br>
-```hl_lines="5"
-repository.apache-mynewt-core:
-    type: github
-    vers: 1-latest
-    user: apache
-    repo: incubator-mynewt-core
-```
+You must edit the `project.yml` file and change the line `repo: incubator-mynewt-core` to `repo: mynewt-core`.
 
 <br>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -553,6 +553,8 @@ pages:
             - 'Install Newtmgr On Mac OS': 'newtmgr/install_mac.md'
             - 'Install Newtmgr On Linux':  'newtmgr/install_linux.md'
             - 'Install Newtmgr On Windows':  'newtmgr/install_windows.md'
+    - Known Issues: 'known_issues.md'
+
 - Appendix:
     - 'Setting Up Go to Contribute to Newt and Newtmgr Tools': 'faq/go_env.md'
     - 'Using an IDE to Develop Mynewt Applications': 'faq/ide.md'


### PR DESCRIPTION
**PLEASE MERGE INTO DEVELOP AND 1.0 BRANCH**
1) Added note to change incubator-mynewt-core to mynewt-core
2) Added not to use Go 1.7.6 or higher if building from source
3) Created Known Issues page and added this issue to it.