### PR TITLE
Updated note for HTTP redirect error.

### DIFF
--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -7,18 +7,12 @@ Here is a list of known issues and workarounds:
         ReadDesc: No matching branch for apache-mynewt-core repo
         No matching branch for apache-mynewt-core repo 
 
-    If you installed a binary version of newt 1.0 or built newt from source using Go version 1.7.5 or earlier, you might see this error because the apache-mynewt-core Git repository location changed due to Mynewt's graduation from an incubator project to an Apache top level project. Go does not support HTTP redirect in Go versions 1.7.5 or earlier.  You can use one of the following workarounds:
+    The apache-mynewt-core Git repository location has changed due to Mynewt's graduation from an incubator project to an Apache top level project.  The HTTP redirect to the new location may fail for some users.  
 
-       **Workaround 1:** Edit the `project.yml` file and change the line `repo: incubator-mynewt-core` as shown in the following example to `repo: mynewt-core`:
+       **Workaround:** Edit the `project.yml` file and change the line `repo: incubator-mynewt-core` as shown in the following example to `repo: mynewt-core`:
 
             repository.apache-mynewt-core:
                 type: github
                 vers: 1-latest
        	        user: apache
                 repo: incubator-mynewt-core
-
-       **Workaround 2:** If you are buiding newt from source, use Go version 1.7.6 or higher to build newt. You can download Go from [https://golang.org/dl/](https://golang.org/dl/).
- 
-      
-
-

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -10,7 +10,7 @@ This guide shows you how to:
 2. Test the project packages. (Not supported on Windows.)
 3. Build and run the simulated blinky application. (Not supported on Windows.) 
 
-**Note:** The apache-mynewt-core Git repository location has changed due to Mynewt's graduation from an incubator project to an Apache top level project. If you installed a binary version of newt 1.0 or built newt from source using Go version 1.7.5 or earlier, you will get the following error when you run the `newt install` step in this tutorial: 
+**Note:** The apache-mynewt-core Git repository location has changed due to Mynewt's graduation from an incubator project to an Apache top level project.  The HTTP redirect to the new location may fail and you may get the following error when you run the `newt install` step in this tutorial:
 
 ```no-highlight
 ReadDesc: No matching branch for apache-mynewt-core repo


### PR DESCRIPTION
- Removed rebuild as a workaround.
- Removed reason for failure.