### PR TITLE
Organize tutorial TOC by category.

### DIFF
--- a/docs/os/tutorials/tutorials.md
+++ b/docs/os/tutorials/tutorials.md
@@ -39,15 +39,15 @@ The tutorials fall into a few broad categories. Some examples in each category a
 
 <br>
 
-* Tooling
-    * [SEGGER RTT](segger_rtt.md)
-    * [SEGGER SystemView](segger_sysview.md)
+* Bluetooth Low Energy
+    * [Building a Bare Bones BLE Application](ble_bare_bones.md)
+    * [Building a BLE iBeacon Application](ibeacon.md)
 
 <br>
 
-* Bluetooth Low Energy
-    * [Running the example BLE app included in the repo](bletiny_project.md)
-    * [Working with another example BLE app for a peripheral device](bleprph/bleprph-intro.md)
+* Tooling
+    * [SEGGER RTT](segger_rtt.md)
+    * [SEGGER SystemView](segger_sysview.md)
 
 <br>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,32 +51,38 @@ pages:
             - 'Slinky on sim device': 'os/tutorials/project-sim-slinky.md'
             - 'Slinky on Nordic nRF52': 'os/tutorials/project-nrf52-slinky.md'
             - 'Slinky on Olimex': 'os/tutorials/project-stm32-slinky.md'
-        - 'Upgrade an Image Over-The-Air': 'os/tutorials/ota_upgrade_nrf52.md'
-        - 'BLE Bare Bones Application': 'os/tutorials/ble_bare_bones.md'
-        - 'BLE iBeacon': 'os/tutorials/ibeacon.md'
-        - 'BLE Eddystone': 'os/tutorials/eddystone.md'
-        - 'BLE Peripheral Project':
-            - toc: 'os/tutorials/bleprph/bleprph-intro.md'
-            - 'Service Registration': 'os/tutorials/bleprph/bleprph-svc-reg.md'
-            - 'Characteristic Access': 'os/tutorials/bleprph/bleprph-chr-access.md'
-            - 'Advertising': 'os/tutorials/bleprph/bleprph-adv.md'
-            - 'GAP Event Callbacks': 'os/tutorials/bleprph/bleprph-gap-event.md'
-            - 'BLE Peripheral App' : 'os/tutorials/bleprph/bleprph-app.md'
-        - 'Enable Newt Manager in any app': 'os/tutorials/add_newtmgr.md' 
-        - 'Enable the OS Shell and Console': 'os/tutorials/add_shell.md'
-        - 'How to Reduce Application Code Size': 'os/tutorials/codesize.md'
-        - 'Tasks and Priority Management': 'os/tutorials/tasks_lesson.md'
-        - 'Enable Wi-Fi on Arduino MKR1000': 'os/tutorials/wi-fi_on_arduino.md'
-        - 'Write a Test Suite for a Package': 'os/tutorials/unit_test.md'
-        - 'Events and Event Queues': 'os/tutorials/event_queue.md'
-        - 'BLE app to check stats via console': 'os/tutorials/bletiny_project.md'
-        - 'BLE HCI interface': 'os/tutorials/blehci_project.md'
-        - 'Air-quality Sensor project':
-            - 'Basic Air Quality Sensor': 'os/tutorials/air_quality_sensor.md'
-            - 'BLE-enabled Air Quality Sensor': 'os/tutorials/air_quality_ble.md'
-        - 'Add an Analog Sensor': 'os/tutorials/nrf52_adc.md'
-        - 'Segger RTT': 'os/tutorials/segger_rtt.md'
-        - 'Segger Sysview': 'os/tutorials/segger_sysview.md'
+        - Bluetooth Low Energy:
+            - 'BLE Bare Bones Application': 'os/tutorials/ble_bare_bones.md'
+            - 'BLE iBeacon': 'os/tutorials/ibeacon.md'
+            - 'BLE Eddystone': 'os/tutorials/eddystone.md'
+            - 'BLE Peripheral Project':
+                - toc: 'os/tutorials/bleprph/bleprph-intro.md'
+                - 'Service Registration': 'os/tutorials/bleprph/bleprph-svc-reg.md'
+                - 'Characteristic Access': 'os/tutorials/bleprph/bleprph-chr-access.md'
+                - 'Advertising': 'os/tutorials/bleprph/bleprph-adv.md'
+                - 'GAP Event Callbacks': 'os/tutorials/bleprph/bleprph-gap-event.md'
+                - 'BLE Peripheral App' : 'os/tutorials/bleprph/bleprph-app.md'
+            - 'BLE HCI interface': 'os/tutorials/blehci_project.md'
+        - OS Fundamentals:
+            - 'Events and Event Queues': 'os/tutorials/event_queue.md'
+            - 'Tasks and Priority Management': 'os/tutorials/tasks_lesson.md'
+        - Image Upgrade and Management:
+            - 'Enable Newt Manager in any app': 'os/tutorials/add_newtmgr.md' 
+            - 'Upgrade an Image Over-The-Air': 'os/tutorials/ota_upgrade_nrf52.md'
+            - 'BLE app to check stats via console': 'os/tutorials/bletiny_project.md'
+        - 'Tooling':
+            - 'Segger RTT': 'os/tutorials/segger_rtt.md'
+            - 'Segger Sysview': 'os/tutorials/segger_sysview.md'
+        - 'Sensors':
+            - 'Air-quality Sensor project':
+                - 'Basic Air Quality Sensor': 'os/tutorials/air_quality_sensor.md'
+                - 'BLE-enabled Air Quality Sensor': 'os/tutorials/air_quality_ble.md'
+            - 'Add an Analog Sensor': 'os/tutorials/nrf52_adc.md'
+        - 'Other':
+            - 'Enable the OS Shell and Console': 'os/tutorials/add_shell.md'
+            - 'How to Reduce Application Code Size': 'os/tutorials/codesize.md'
+            - 'Write a Test Suite for a Package': 'os/tutorials/unit_test.md'
+            - 'Enable Wi-Fi on Arduino MKR1000': 'os/tutorials/wi-fi_on_arduino.md'
     - OS User Guide:
         - toc: 'os/os_user_guide.md'
         - OS Core:


### PR DESCRIPTION
I find the tutorial table of contents in the sidebar to be difficult to navigate.  This PR organizes the table of contents by category.

I didn't put too much thought into how these get categorized, but I think it is a good starting point.  If we want to keep the tutorials categorized, then all comments are welcome.  Otherwise, feel free to reject this PR.