### PR TITLE
MYNEWT-776 Update newtmgr docs for 1.1

### DIFF
--- a/docs/newtmgr/command_list/newtmgr_config.md
+++ b/docs/newtmgr/command_list/newtmgr_config.md
@@ -10,10 +10,12 @@ Read and write config values on a device.
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_conn.md
+++ b/docs/newtmgr/command_list/newtmgr_conn.md
@@ -8,17 +8,15 @@ Manage newtmgr connection profiles.
 ```
 
 #### Flags:
-```no-highlight
-    -h, --help   help for conn
-```
+
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-        --name string       name of target BLE device; overrides profile setting
-    -l, --loglevel string   log level to use (default "info")
-    -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
-    -r, --tries int         total number of tries in case of timeout (default 1)
+  -c, --conn string       connection profile to use
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_crash.md
+++ b/docs/newtmgr/command_list/newtmgr_crash.md
@@ -5,16 +5,18 @@ Send a crash command to a device.
 #### Usage:
 
 ```no-highlight
-    newtmgr crash <div0|jump0|ref0|assert|wdog> -c <conn_profile> [flags] 
+    newtmgr crash <assert|div0|jump0|ref0|wdog> -c <conn_profile> [flags] 
 ```
 
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_datetime.md
+++ b/docs/newtmgr/command_list/newtmgr_datetime.md
@@ -4,16 +4,18 @@ Manage datetime on a device.
 #### Usage:
 
 ```no-highlight
-    newtmgr datetime [datetime-value] -c <conn_profile> [flags] 
+    newtmgr datetime [rfc-3339-date-string] -c <conn_profile> [flags]
 ```
 
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_echo.md
+++ b/docs/newtmgr/command_list/newtmgr_echo.md
@@ -10,10 +10,12 @@ Send data to a device and display the echoed back data.
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_fs.md
+++ b/docs/newtmgr/command_list/newtmgr_fs.md
@@ -10,10 +10,12 @@ Access files on a device.
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_image.md
+++ b/docs/newtmgr/command_list/newtmgr_image.md
@@ -8,11 +8,6 @@ Manage images on a device.
 ```
 
 #### Flags:
-
-```no-highlight
-    -h, --help   help for image
-```
-<br>
 The coredownload subcommand uses the following local flags:
 
 ```no-highlight
@@ -25,11 +20,12 @@ The coredownload subcommand uses the following local flags:
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use
-    -l, --loglevel string   log level to use (default "info")
-        --name string       name of target BLE device; overrides profile setting
-    -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
-    -r, --tries int         total number of tries in case of timeout (default 1)
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 <br>
 ####Description

--- a/docs/newtmgr/command_list/newtmgr_logs.md
+++ b/docs/newtmgr/command_list/newtmgr_logs.md
@@ -4,16 +4,18 @@ Manage logs on a device.
 #### Usage:
 
 ```no-highlight
-    newtmgr log [command] [flags] 
+    newtmgr log [command] -c <conn_profile> [flags] 
 ```
 
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description
@@ -25,8 +27,7 @@ clear      | The newtmgr log clear command clears the logs on a device.
 level_list | The newtmgr level_list command shows the log levels on a device.
 list      | The newtmgr log list command shows the log names on a device. 
 module_list | The newtmgr log module_list command shows the log module names on a device. 
-show      | The newtmgr log show command shows the logs on a device.
-    
+show  | The newtmgr log show command displays logs on a device. The command format is: <br>newtmgr log show [log_name [min-index [min-timestamp]]] -c &lt;conn_profile&gt;<br><br>The following optional parameters can be used to filter the logs to display: <ul><li>**log_name**: Name of log to display. If log_name is not specified, all logs are displayed.</li><li>**min-index**: Minimum index of the log entries to display. This value is only valid when a log_name is specified. The value can be `last` or a number. If the value is `last`, only the last log entry is displayed. If the value is a number, log entries with an index equal to or higher than min-index are displayed.</li><li>**min-timestamp**: Minimum timestamp of log entries to display. The value is only valid if min-index is specified and is not the value `last`. Only log entries with a timestamp equal to or later than min-timestamp are displayed. Log entries with a timestamp equal to min-timestamp are only displayed if the log entry index is equal to or higher than min-index.</li></ul> 
 
 #### Examples
 
@@ -35,5 +36,9 @@ Sub-command  | Usage                  | Explanation
 clear       | newtmgr log clear<br>-c profile01 | Clears the logs on a device. Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
 level_list   | newtmgr log level_list <br>-c profile01  | Shows the log levels on a device. Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
 list   | newtmgr log list<br>-c profile01  | Shows the log names on a device. Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
-module_list   | newtmgr log module_list<br>-c profile01  | Shows the log module names on a device. Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
-show  | newtmgr log show<br>-c profile01  | Shows the logs on a device. Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
+module_list   | newtmgr log module_list<br>-c profile01  | Shows the log module names on a device. Newtmgr connects to the device over a connection specified in the `profile01` connection profile. 
+show  | newtmgr log show -c profile01  | Displays all logs on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
+show  | newtmgr log show reboot_log -c profile01  | Displays all log entries for the reboot_log on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
+show | newtmgr log show reboot_log last -c profile01 | Displays the last entry from the reboot_log on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
+show | newtmgr log show reboot_log 2 -c profile01 | Displays the reboot_log log entries with an index 2 and higher on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
+show | newtmgr log show reboot_log 5 123456 -c profile01 | Displays the reboot_log log entries with a timestamp higher than 123456 and log entries with a timestamp equal to 123456 and an index equal to or higher than 5.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.

--- a/docs/newtmgr/command_list/newtmgr_mpstats.md
+++ b/docs/newtmgr/command_list/newtmgr_mpstats.md
@@ -10,10 +10,12 @@ Read memory pool statistics from a device.
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_mpstats.md
+++ b/docs/newtmgr/command_list/newtmgr_mpstats.md
@@ -37,22 +37,21 @@ Sub-command  | Usage                  | Explanation
 Here is an example output for the `myble` application from the [Enabling Newt Manager in any app](/os/tutorials/add_newtmgr.md) tutiorial:
 
 ```no-highlight
-newtmgr mpstat -c myserial 
-Return Code = 0
-                            name blksz  cnt free  min
-         ble_l2cap_sig_proc_pool    20    1    1    1
-     ble_att_svr_prep_entry_pool    12   64   64   64
-         ble_hci_ram_evt_hi_pool    72    2    2    1
-              ble_hs_hci_ev_pool    16   10   10    9
+$ newtmgr mpstat -c myserial 
+                         name blksz  cnt free  min
           ble_att_svr_entry_pool    20   75    0    0
-             ble_gattc_proc_pool    56    4    4    4
-                bletiny_dsc_pool    28   64   64   64
-                ble_hs_conn_pool    84    1    1    1
+     ble_att_svr_prep_entry_pool    12   64   64   64
                   ble_gap_update    24    1    1    1
-                bletiny_svc_pool    32   32   32   32
+             ble_gattc_proc_pool    56    4    4    4
           ble_gatts_clt_cfg_pool    12    2    1    1
-                          msys_1   292   12    9    6
+         ble_hci_ram_evt_hi_pool    72    2    2    1
          ble_hci_ram_evt_lo_pool    72    8    8    8
-             ble_l2cap_chan_pool    24    3    3    3
+                ble_hs_conn_pool    92    1    1    1
+              ble_hs_hci_ev_pool    16   10   10    9
+             ble_l2cap_chan_pool    28    3    3    3
+         ble_l2cap_sig_proc_pool    20    1    1    1
                 bletiny_chr_pool    36   64   64   64
+                bletiny_dsc_pool    28   64   64   64
+                bletiny_svc_pool    36   32   32   32
+                          msys_1   292   12    9    6
 ```

--- a/docs/newtmgr/command_list/newtmgr_reset.md
+++ b/docs/newtmgr/command_list/newtmgr_reset.md
@@ -10,10 +10,12 @@ Send a reset request to a device.
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_reset.md
+++ b/docs/newtmgr/command_list/newtmgr_reset.md
@@ -4,7 +4,7 @@ Send a reset request to a device.
 #### Usage:
 
 ```no-highlight
-    newtmgr reset <conn_profile> [flags] 
+    newtmgr reset -c <conn_profile> [flags] 
 ```
 
 #### Global Flags:

--- a/docs/newtmgr/command_list/newtmgr_run.md
+++ b/docs/newtmgr/command_list/newtmgr_run.md
@@ -10,10 +10,12 @@ Run test procedures on a device.
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_stat.md
+++ b/docs/newtmgr/command_list/newtmgr_stat.md
@@ -4,17 +4,19 @@ Read statistics from a device.
 #### Usage:
 
 ```no-highlight
-    newtmgr stat [stats_name] -c <conn_profile> [flags] 
+    newtmgr stat <stats_name> -c <conn_profile> [flags] 
     newtmgr stat [command] -c <conn_profile> [flags] 
 ```
 
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description
@@ -22,7 +24,7 @@ Displays statistic for the Stats named `stats_name` from a device.  You can use 
 
 Sub-command  |  Explanation
 -------------| -----------------------
-             | The newtmgr stat [stats_name] command displays the statistics for the `stats_name` Stats from a device. It displays the list of Stats names if a `stats_name` value is not specified.
+             | The newtmgr stat <stats_name> command displays the statistics for the `stats_name` Stats from a device. 
 list         | The newtmgr stat list command displays the list of Stats names from a device.  
 
 
@@ -31,7 +33,6 @@ list         | The newtmgr stat list command displays the list of Stats names fr
 Sub-command  | Usage                  | Explanation
 -------------| -----------------------|-----------------
              | newtmgr stat ble_att -c profile01 | Displays the `ble_att` statistics on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
-             | newtmgr stat -c profile01 | Displays the list of Stats names from a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
 list         | newtmgr stat list -c profile01 | Displays the list of Stats names from a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
  
 Here are some example outputs for the `myble` application from the [Enabling Newt Manager in any app](/os/tutorials/add_newtmgr.md) tutiorial:
@@ -64,15 +65,7 @@ Stats Name: ble_att
 
 ```
 
-The list of Stats names:
-```no-highlight
-
-$ newtmgr stat -c myserial
-[stat ble_l2cap ble_att ble_gap ble_gattc ble_gatts ble_hs ble_ll_conn ble_ll ble_phy]
-Return Code = 0
-
-```
-The list of Stats names  using the list subcommand:
+The list of Stats names using the list subcommand:
 ```no-highlight
 
 $ newtmgr stat list -c myserial

--- a/docs/newtmgr/command_list/newtmgr_stat.md
+++ b/docs/newtmgr/command_list/newtmgr_stat.md
@@ -41,35 +41,51 @@ The statistics for the ble_att Stats:
 ```no-highlight
 
 $ newtmgr stat ble_att -c myserial
-Return Code = 0
-Stats Name: ble_att
-  read_type_req_rx: 0
-  read_rsp_rx: 0
-  read_group_type_rsp_tx: 0
-  prep_write_rsp_tx: 0
-  find_type_value_req_tx: 0
-  read_type_rsp_rx: 0
-  read_mult_req_rx: 0
-  notify_req_tx: 0
-  indicate_req_tx: 0
+stat group: ble_att
+         0 error_rsp_rx
+         0 error_rsp_tx
+         0 exec_write_req_rx
+         0 exec_write_req_tx
+         0 exec_write_rsp_rx
+         0 exec_write_rsp_tx
+         0 find_info_req_rx
+         0 find_info_req_tx
+         0 find_info_rsp_rx
+         0 find_info_rsp_tx
+         0 find_type_value_req_rx
+         0 find_type_value_req_tx
+         0 find_type_value_rsp_rx
+         0 find_type_value_rsp_tx
 
-       ...
-  write_cmd_rx: 0
-  prep_write_rsp_rx: 0
-  read_type_rsp_tx: 0
-  read_req_tx: 0
-  read_mult_req_tx: 0
-  read_group_type_req_rx: 0
-  write_rsp_tx: 0
-  exec_write_rsp_rx: 0
+               ...
 
+         0 read_rsp_rx
+         0 read_rsp_tx
+         0 read_type_req_rx
+         0 read_type_req_tx
+         0 read_type_rsp_rx
+         0 read_type_rsp_tx
+         0 write_cmd_rx
+         0 write_cmd_tx
+         0 write_req_rx
+         0 write_req_tx
+         0 write_rsp_rx
+         0 write_rsp_tx
 ```
-
+<br>
 The list of Stats names using the list subcommand:
 ```no-highlight
 
 $ newtmgr stat list -c myserial
-[stat ble_l2cap ble_att ble_gap ble_gattc ble_gatts ble_hs ble_ll_conn ble_ll ble_phy]
-Return Code = 0
-
+stat groups:
+    ble_att
+    ble_gap
+    ble_gattc
+    ble_gatts
+    ble_hs
+    ble_l2cap
+    ble_ll
+    ble_ll_conn
+    ble_phy
+    stat
 ```

--- a/docs/newtmgr/command_list/newtmgr_taskstats.md
+++ b/docs/newtmgr/command_list/newtmgr_taskstats.md
@@ -10,10 +10,12 @@ Read task statistics from a device.
 #### Global Flags:
 
 ```no-highlight
-    -c, --conn string       connection profile to use.
-    -h, --help              Help for newtmgr commands
-    -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
+  -l, --loglevel string   log level to use (default "info")
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```
 
 #### Description

--- a/docs/newtmgr/command_list/newtmgr_taskstats.md
+++ b/docs/newtmgr/command_list/newtmgr_taskstats.md
@@ -40,10 +40,9 @@ Sub-command  | Usage                  | Explanation
 Here is an example output for the `myble` application from the [Enabling Newt Manager in any app](/os/tutorials/add_newtmgr.md) tutiorial:
 
 ```no-highlight
-newtmgr taskstat -c myserial 
-Return Code = 0
+$ newtmgr taskstat -c myserial 
       task pri tid  runtime      csw    stksz   stkuse last_checkin next_checkin
-      idle 255   0   151917       47       64       34        0        0
-      main 127   1        2       59      512      188        0        0
-    ble_ll   0   2        0       14       80       56        0        0
+    ble_ll   0   2        0       12       80       58        0        0
+      idle 255   0    16713       95       64       31        0        0
+      main 127   1        2       81      512      275        0        0
 ```

--- a/docs/newtmgr/overview.md
+++ b/docs/newtmgr/overview.md
@@ -8,24 +8,26 @@ The following are the high-level newtmgr commands. Some of these commands have s
 
 ```no-highlight
 Available Commands:
-
   config      Read or write a config value on a device
   conn        Manage newtmgr connection profiles
   crash       Send a crash command to a device
   datetime    Manage datetime on a device
   echo        Send data to a device and display the echoed back data
   fs          Access files on a device
+  help        Help about any command
   image       Manage images on a device
   log         Manage logs on a device
-  mpstat      Read memory pool statistics from a device
-  reset       Send reset request to a device
+  mpstat      Read mempool statistics from a device
+  reset       Perform a soft reset of a device
   run         Run test procedures on a device
   stat        Read statistics from a device
   taskstat    Read task statistics from a device
 
 Flags:
-  -c, --conn string       connection profile to use.
-  -h, --help              Help for newtmgr commands
+  -c, --conn string       connection profile to use
+  -h, --help              help for newtmgr
   -l, --loglevel string   log level to use (default "info")
-  -t, --trace             print all bytes transmitted and received
+      --name string       name of target BLE device; overrides profile setting
+  -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+  -r, --tries int         total number of tries in case of timeout (default 1)
 ```

--- a/docs/os/tutorials/project-nrf52-slinky.md
+++ b/docs/os/tutorials/project-nrf52-slinky.md
@@ -214,11 +214,10 @@ Run the `newtmgr taskstat -c nrf52serial` command to display the task statistics
 
 ```no-highlight
 $ newtmgr taskstat -c nrf52serial
-Return Code = 0
       task pri tid  runtime      csw    stksz   stkuse last_checkin next_checkin
-     task1   8   2        0     1751      192      110        0        0
-     task2   9   3        0     1751       64       31        0        0
-      idle 255   0   224081     2068       64       32        0        0
-      main 127   1        3       29     1024      365        0        0
+      idle 255   0    43484      539       64       32        0        0
+      main 127   1        1       90     1024      353        0        0
+     task1   8   2        0      340      192      114        0        0
+     task2   9   3        0      340       64       31        0        0
 $
 ```

--- a/docs/os/tutorials/project-stm32-slinky.md
+++ b/docs/os/tutorials/project-stm32-slinky.md
@@ -34,7 +34,7 @@ stm32_boot`.
 
 ```no-highlight
 $ newt target create stm32_boot
-$ newt target set stm32_bootr bsp=@apache-mynewt-core/hw/bsp/olimex_stm32-e407_devboard
+$ newt target set stm32_boot bsp=@apache-mynewt-core/hw/bsp/olimex_stm32-e407_devboard
 $ newt target set stm32_boot build_profile=optimized
 $ newt target set stm32_boot target.app=@apache-mynewt-core/apps/boot
 ```
@@ -102,7 +102,7 @@ $
 Run the `newt create-image stm32_slinky 1.0.0` command to create and sign the application image. You may assign an arbitrary version (e.g. 1.0.0) to the image.
 
 ```no-highlight
-create-image stm32_slinky 1.0.0
+newt create-image stm32_slinky 1.0.0
 App image succesfully generated: ~/dev/slinky/bin/targets/stm32_slinky/app/apps/slinky/slinky.img
 $
 ```
@@ -234,7 +234,6 @@ Run the `newtmgr taskstat -c stm32serial` command to display the task statistics
 
 ```no-highlight
 $ newtmgr taskstat -c stm32serial
-Return Code = 0
       task pri tid  runtime      csw    stksz   stkuse last_checkin next_checkin
      task1   8   2        0       90      192      110        0        0
      task2   9   3        0       90       64       31        0        0


### PR DESCRIPTION
1. Update new global flags for newtmgr 1.1
2. Updated slinky tutorials
3. Updated newtmgr log show command usage.
4. Updated newtmgr stat command syntax.  In 1.0 you can use `newtmgr stat` with no arguments to get a list of stat names. The command no longer support this. You can only use `newtmgr stat list` to get the stat names
5. Typo fixes. 