### PR TITLE
[DO NOT MERGE THIS UNTIL sensor apps are in apple and play store] Add links and notes about the mynewt smart device app.

### DIFF
--- a/docs/os/tutorials/sensors/sensor_bleprph_oic.md
+++ b/docs/os/tutorials/sensors/sensor_bleprph_oic.md
@@ -7,7 +7,7 @@ This tutorial shows you how to:
 
 * Modify the bleprph_oic application to add OIC sensor support.
 * Create and build the target for the new application.
-* Use the Mynewt Smart Device Controller [Android](https://github.com/runtimeco/android_sensor) or iOS app to view the sensor data from the device.
+* Use the Mynewt Smart Device Controller iOS or Android app to view the sensor data from the device.
 
 ### Prerequisites
 

--- a/docs/os/tutorials/sensors/sensor_nrf52_bno055_oic.md
+++ b/docs/os/tutorials/sensors/sensor_nrf52_bno055_oic.md
@@ -7,13 +7,12 @@ Like the other off-board sensor tutorials, this tutorial uses an nRF52-DK board 
 This tutorial shows you how to:
 
 * Create and build the target to enable sensor OIC support in the sensors_test application. 
-* Use the Mynewt Smart Device Controller [Android](https://github.com/runtimeco/android_sensor) or iOS app to view the sensor data from the device. 
+* Use the Mynewt Smart Device Controller Android or iOS app to view the sensor data from the device. 
 <br>
 
 ### Prerequisite
 
-* Read the [Overview of OIC Support in the Sensor Framework](/os/tutorials/sensors/sensor_oic_overview.md).
-* Complete the tasks described in the [Enabling an Off-Board Sensor in an Existing Application Tutorial](/os/tutorials/sensors/sensor_nrf52_bno055.md). 
+Read the [Overview of OIC Support in the Sensor Framework](/os/tutorials/sensors/sensor_oic_overview.md).
 
 ### Step 1: Creating and Building the sensors_test Application Image
 
@@ -81,7 +80,7 @@ Perform the following steps to reboot the board with the new images:
 <br>
 ### Step 3: Viewing Sensor Data from the Mynewt Smart Device Controller
 
-Start the Mynewt Smart Device Controller app on your iOS or Android device to view the sensor data.  If you have not installed the Mynewt Smart Device Controller app, follow the instructions in [Installing the Mynewt Smart Device Controller](https://github.com/runtimeco/android_sensor) to install the app, then continue with this step of the tutorial.
+Start the Mynewt Smart Device Controller app on your iOS or Android device to view the sensor data.  If you have not installed the Mynewt Smart Device Controller follow the instructions in the [Sensor Tutorials Overview](/os/tutorials/sensors/sensors.md) to install the app, then continue with this step of the tutorial.
 
 <br>
 The Mynewt Smart Device Controller scans for the devices when it starts up and displays the sensors it can view. The following is an example from the Android App: 

--- a/docs/os/tutorials/sensors/sensor_oic_overview.md
+++ b/docs/os/tutorials/sensors/sensor_oic_overview.md
@@ -4,7 +4,7 @@ This tutorial shows you how to enable sensor data monitoring via the OIC protoco
 
 This tutorial has two parts:
 
-* [Part 1](/os/tutorials/sensors/sensor_nrf52_bno055_oic.md) shows you how to enable OIC sensor support in the sensors_test application. The procedure only requires setting the appropriate syscfg setting values for the application target. The objective is to show you to quickly bring up the sensors_test application and view the sensor data with the Mynewt Smart Device Controller OIC app that is available for iOS and [Android](https://github.com/runtimeco/android_sensor) devices.
+* [Part 1](/os/tutorials/sensors/sensor_nrf52_bno055_oic.md) shows you how to enable OIC sensor support in the sensors_test application. The procedure only requires setting the appropriate syscfg setting values for the application target. The objective is to show you to quickly bring up the sensors_test application and view the sensor data with the Mynewt Smart Device Controller app that is available for iOS and Android devices. 
 
 * [Part 2](/os/tutorials/sensors/sensor_bleprph_oic.md) shows you how to modify the bleprph_oic application code to add OIC sensor support. The objective is to show you how to use the Sensor Framework API and OIC server API to develop an OIC over BLE sensor server application.
 <br>
@@ -12,7 +12,7 @@ This tutorial has two parts:
 Ensure that you meet the following prerequisites before continuing with the tutorials:
 
 * Complete the [Enabling an Off-Board Sensor in an Existing Application Tutorial](/os/tutorials/sensors/sensor_nrf52_bno055.md).
-* Install the Mynewt Smart Device Controller on an iOS or Android Device. See the [Instalation for Android](https://github.com/runtimeco/android_sensor) and the [Installation for iOS](...).
+* Install the Mynewt Smart Device Controller on an iOS or Android Device.  See the [Sensor Tutorials Overview](/os/tutorials/sensors/sensors.md) on how to install the Mynewt Smart Device Controller app. 
 
 ### Overview of OIC Support in the Sensor Framework
 

--- a/docs/os/tutorials/sensors/sensors.md
+++ b/docs/os/tutorials/sensors/sensors.md
@@ -24,6 +24,8 @@ The tutorials are:
 
 We use the Mynewt Smart Device Controller App on iOS or Android to retrieve and display sensor data from the Mynewt OS OIC sensor applications described in the OIC Sensor Data Monitoring tutorials. You can download the app from either the Apple Store or Google Play Store. 
 
+**Note:** At the time of writing this tutorial, the iOS app was still in the queue waiting to be placed in the App Store. You can build the iOS app from source as indicated below.
+
 If you would like to contribute or modify the Mynewt Smart Device Controller App, see the [Android Sensor source](https://github.com/runtimeco/android_sensor) and [iOS Sensor source](https://github.com/runtimeco/iOS_oic) on github.
 
 <br>

--- a/docs/os/tutorials/sensors/sensors.md
+++ b/docs/os/tutorials/sensors/sensors.md
@@ -20,6 +20,11 @@ The tutorials are:
 
 * [Enabling OIC Sensor Data Monitoring in an Existing Application](/os/tutorials/sensors/sensor_oic_overview.md) - This tutorial shows you how to enable support for sensor data monitoring via OIC in an existing application.
 
+### Mynewt Smart Device Controller OIC App
+
+We use the Mynewt Smart Device Controller App on iOS or Android to retrieve and display sensor data from the Mynewt OS OIC sensor applications described in the OIC Sensor Data Monitoring tutorials. You can download the app from either the Apple Store or Google Play Store. 
+
+If you would like to contribute or modify the Mynewt Smart Device Controller App, see the [Android Sensor source](https://github.com/runtimeco/android_sensor) and [iOS Sensor source](https://github.com/runtimeco/iOS_oic) on github.
 
 <br>
 ### Prerequisites

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -356,9 +356,9 @@ pages:
                 - 'Sensor Manager API': 'os/modules/sensor_framework/sensor_mgr_api.md'
                 - 'Sensor Listener API': 'os/modules/sensor_framework/sensor_listener_api.md'
                 - 'OIC Sensor API': 'os/modules/sensor_framework/sensor_oic.md'
+            -  'Sensor Shell': 'os/modules/sensor_framework/sensor_shell.md'
             - 'Sensor Device Driver': 'os/modules/sensor_framework/sensor_driver.md'
             - 'Creating and Configuring Sensor Devices': 'os/modules/sensor_framework/sensor_create.md'
-            -  'Sensor Shell': 'os/modules/sensor_framework/sensor_shell.md'
         - Drivers:
             - toc: 'os/modules/drivers/driver.md'
             - 'Supported Drivers':


### PR DESCRIPTION
- Added write up about thr mynewt smart device app in sensor tutorials overview page. Tell user to instal app from apple store and google play store.
- Added links to the android sensor source and ios sensor source.
- Added links from oic tutorials to sensor tutorials overview for installation instructions.
Note this assumes the the apps will be added to the apple store and the google pay store.
- Reordered Sensor Shell in Sensor Framework OS Guide Sidebar