### PR TITLE
Updated ota upgrade tutorial to reduce log level.

### DIFF
--- a/docs/os/tutorials/ota_upgrade_nrf52.md
+++ b/docs/os/tutorials/ota_upgrade_nrf52.md
@@ -18,7 +18,21 @@ Ensure that you meet the following prerequisites:
 * Read the [Bootloader](/os/modules/bootloader/bootloader) section and understand the Mynewt bootloader concepts.
 * Build and load the **bleprph** application on to an nRF52-DK board via a serial connection. See [BLE Peripheral App](/os/tutorials/bleprph/bleprph-app/). 
 
+<br>
+### Reducing the Log Level
 
+You need to build your application with log level set to INFO or lower. The default log level for the **bleprph** app is set to DEBUG. The extra logging causes the communication to timeout. Perform the following to reduce the log level to INFO, build, and load the application. 
+
+```no-highlight
+
+$ newt target amend myperiph syscfg="LOG_LEVEL=1"
+$ newt build myperiph
+$ newt create-image myperiph 1.0.0
+$ newt load myperiph
+
+```
+
+<br>
 ### Upgrading an Image on a Device 
 Once you have an application with newtmgr image management with BLE transport support running on a device, you can use the newtmgr tool to upgrade an image over-the-air. 
 


### PR DESCRIPTION
When log level is set to DEBUG, the extra logging causes communication to timeout and the upload fails. Lowering log level to INFO seems to fix the proble. We tell the user to do that so the tutorial does not fail.