### PR TITLE
Fixed note about bno055 shell command setting.

### DIFF
--- a/docs/os/modules/sensor_framework/sensor_create.md
+++ b/docs/os/modules/sensor_framework/sensor_create.md
@@ -212,4 +212,4 @@ The BSP and sensor creator package use a default configuration and enable all su
 
 We recommend that you copy the `config_<sensorname>_sensor()` function from the BSP or the sensor creator package in to your application code and change the desired settings. Note that you must keep all the fields in the `<sensorname>_cfg` structure initialized with the default values for the settings that you do not want to change.
 
-See the [Changing the Default Configuration for a Sensor Tutorial] (os/tutorials/sensors/sensor_offboard_config/) for more details on how to change the default sensor configuration from an application.
+See the [Changing the Default Configuration for a Sensor Tutorial](/os/tutorials/sensors/sensor_offboard_config/) for more details on how to change the default sensor configuration from an application.

--- a/docs/os/modules/sensor_framework/sensor_framework_overview.md
+++ b/docs/os/modules/sensor_framework/sensor_framework_overview.md
@@ -18,7 +18,7 @@ The Mynewt sensor framework is an abstraction layer between an application and s
 ## Overview of Sensor Support Packages
 
 
-In this guide and and the package source code, we use `SENSORNAME` (all uppercase) to refer to a sensor product name. For each sensor named `SENSORNAME`: 
+In this guide and the package source code, we use `SENSORNAME` (all uppercase) to refer to a sensor product name. For each sensor named `SENSORNAME`: 
 
 * The package name for the sensor device driver is `<sensorname>`. All functions and data structures that the sensor device driver exports are prefixed with `<sensorname>`. 
 

--- a/docs/os/tutorials/sensors/sensor_nrf52_bno055.md
+++ b/docs/os/tutorials/sensors/sensor_nrf52_bno055.md
@@ -54,11 +54,7 @@ When this setting is enabled, the creator package performs the following:
 * `BNO055_CLI`: Enables the `bno055` shell command in the bno055 device driver package. The sensors_test application also uses this setting to conditionally include the call to the `bno055_shell_init()` function to initialize the shell support in the driver.
 
 
-**Note:** The `SENSOR_CLI` setting that specifies whether the `sensor` shell command is enabled is is enabled by default.
-
-
-
-This tutorial uses both shell commands. They are enabled by default so you do not need to explicitly enable the setting for this target.
+**Note:** This tutorial uses the `sensor` and the `bno055` shell commands.  The `SENSOR_CLI` setting, that specifies whether the `sensor` shell command is enabled, is enabled by default.
 
 <br> 
 1. Run the `newt target create` command, from your project base directory,  to create the target. We name the target `nrf52_bno055_test`:


### PR DESCRIPTION
The BNO055_CLI  setting changed from enabled to disabled by default.
In a previous commit, the tutorial was updated to tell the user to enable the setting in the newt target set command, but didn't update a note that told the user the setting was enabled by default.
This commit fixes the note so it doesn't say the setting is enabled by default.