### PR TITLE
Updated 1.2.0 install doc to simplify adding new releases

### DIFF
--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -70,8 +70,7 @@ $ sudo apt-get update
 
 ```no-highlight
 
-W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/source/Sources  Ht
-tpError404
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/source/Sources  HttpError404
 
 ```
 <br>
@@ -101,8 +100,8 @@ $ sudo apt-get install gcc-multilib
 Download and install the package manually.
 
 ```no-highlight
-$ wget https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/pool/main/n/newt/newt_1.2.0-1_amd64.deb
-$ sudo dpkg -i newt_1.2.0-1_amd64.deb
+$wget https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.2.0/newt_1.2.0-1_amd64.deb
+$sudo dpkg -i newt_1.2.0-1_amd64.deb
 ```
 <br>
 See [Checking the Installed Version of Newt](#check) to verify that you are using the installed version of newt.

--- a/docs/newt/install/newt_mac.md
+++ b/docs/newt/install/newt_mac.md
@@ -1,6 +1,6 @@
 ## Installing Newt on Mac OS
 
-Newt is supported on Mac OS X 64 bit platforms and has been tested on Mac OS 10.11 and higher.
+Newt is supported on Mac OS X 64 bit platforms and has been tested on Mac OS Sierra.
 
 This page shows you how to install the following versions of newt:
 
@@ -55,16 +55,9 @@ Run the following command to install the latest release version of newt:
 
 $ brew update
 $ brew install mynewt-newt
-==> Installing mynewt-newt from runtimeco/mynewt
-==> Downloading https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.2.0/mynewt-newt-1.2.0.sierra.bottle.tar.gz
-==> Downloading from https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.2.0/mynewt-newt-1.2.0.sierra.bottle.tar.gz
-######################################################################## 100.0%
-==> Pouring mynewt-newt-1.2.0.sierra.bottle.tar.gz
-🍺  /usr/local/Cellar/mynewt-newt/1.2.0: 3 files, 10.7MB
-
 ```
 <br>
-**Notes:** Homebrew bottles for newt are available for Mac OS Sierra, and El Captian.  If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newt locally.
+**Notes:** Homebrew bottles for newt are available for Mac OS Sierra.  If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newt locally.
 
 <br>
 ### Checking the Installed Version
@@ -75,8 +68,6 @@ Check that you are using the installed version of newt:
 
 $which newt
 /usr/local/bin/newt
-$ls -l /usr/local/bin/newt
-lrwxr-xr-x  1 user  staff  36 Sep 11 19:04 /usr/local/bin/newt -> ../Cellar/mynewt-newt/1.2.0/bin/newt
 $newt version
 Apache Newt version: 1.2.0
 
@@ -162,28 +153,10 @@ $brew unlink mynewt-newt
 Install the latest unstable version of newt from the master branch:
 ```no-highlight
 $ brew install mynewt-newt --HEAD
-==> Installing mynewt-newt from runtimeco/mynewt
-==> Cloning https://github.com/apache/mynewt-newt.git
-Cloning into '/Users/wanda/Library/Caches/Homebrew/mynewt-newt--git'...
-remote: Counting objects: 626, done.
-remote: Compressing objects: 100% (504/504), done.
-remote: Total 626 (delta 155), reused 323 (delta 85), pack-reused 0
-Receiving objects: 100% (626/626), 1.11 MiB | 0 bytes/s, done.
-Resolving deltas: 100% (155/155), done.
-==> Checking out branch master
-==> go install
-🍺  /usr/local/Cellar/mynewt-newt/HEAD-59b3a5d: 3 files, 10.7MB, built in 7 seconds
-$newt version
-Apache Newt version 1.1.0-dev
 ```
 <br>
 To switch back to the latest stable release version of newt, you can run:
 ```no-highlight
 $brew switch mynewt-newt 1.2.0
-Cleaning /usr/local/Cellar/mynewt-newt/1.2.0
-Cleaning /usr/local/Cellar/mynewt-newt/HEAD-59b3a5d
-1 links created for /usr/local/Cellar/mynewt-newt/1.2.0
-$newt version
-Apache Newt version: 1.2.0
 ```
 <br>

--- a/docs/newt/install/newt_windows.md
+++ b/docs/newt/install/newt_windows.md
@@ -8,7 +8,7 @@ This guide shows you how to perform the following:
 
 1. Install MSYS2/MinGW. 
 2. Install Git.
-3. Install latest release of newt (1.2.0) from binary.
+3. Install latest release (1.2.0) of newt from binary.
 4. Install latest release of newt from source.
 
 See [Installing Previous Releases of Newt](/newt/install/prev_releases) to install an earlier version of newt. You still need to set up your MinGW development environment.

--- a/docs/newt/install/prev_releases.md
+++ b/docs/newt/install/prev_releases.md
@@ -65,7 +65,7 @@ Version|Download
 
 Version|Download
 -------|--------
-1.1.0  |[newt_1_1_0_windows_amd64.tar.gz](https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.1.0/newt_1.1.0-1_amd64.deb)
+1.1.0  |[newt_1_1_0_windows_amd64.tar.gz](https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.1.0/newt_1_1_0_windows_amd64.tar.gz)
 
 <br>
 2. Extract the file:

--- a/docs/newtmgr/install_linux.md
+++ b/docs/newtmgr/install_linux.md
@@ -85,8 +85,7 @@ $sudo apt-get update
 
 ```no-highlight
 
-W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/source/Sources  Ht
-tpError404
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/source/Sources  HttpError404
 
 ```
 <br> 
@@ -111,7 +110,7 @@ $ sudo apt-get install newtmgr
 Download and install the package manually.
 
 ```no-highlight
-$wget https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/pool/main/n/newtmgr/newtmgr_1.2.0-1_amd64.deb
+$wget https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.2.0/newtmgr_1.2.0-1_amd64.deb
 $sudo dpkg -i newtmgr_1.2.0-1_amd64.deb
 ```
 

--- a/docs/newtmgr/install_mac.md
+++ b/docs/newtmgr/install_mac.md
@@ -1,6 +1,6 @@
 ## Installing Newtmgr on Mac OS
 
-Newtmgr is supported on Mac OS X 64 bit platforms and has been tested on Mac OS 10.11 and higher.
+Newtmgr is supported on Mac OS X 64 bit platforms and has been tested on Mac OS Sierra.
 
 This page shows you how to install the following versions of newtmgr:
 
@@ -46,16 +46,9 @@ Run the following command to install the latest release version of newtmgr:
 
 $ brew update
 $ brew install mynewt-newtmgr
-==> Installing mynewt-newtmgr from runtimeco/mynewt
-==> Downloading https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.2.0/mynewt-newtmgr-1.2.0.sierra.bottle.tar.gz
-==> Downloading from https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.2.0/mynewt-newtmgr-1.2.0.sierra.bottle.tar.gz
-######################################################################## 100.0%
-==> Pouring mynewt-newtmgr-1.2.0.sierra.bottle.tar.gz
-🍺  /usr/local/Cellar/mynewt-newtmgr/1.2.0: 3 files, 17.3MB
-
 ```
 <br>
-**Notes:** Homebrew bottles for newtmgr 1.2.0 are available for Mac OS Sierra, El Captian.  If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newtmgr locally.
+**Notes:** Homebrew bottles for newtmgr 1.2.0 are available for Mac OS Sierra.  If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newtmgr locally.
 
 <br>
 ### Checking the Installed Version
@@ -64,8 +57,6 @@ Check that you are using the installed version of newtmgr:
 ```no-highlight
 $which newtmgr
 /usr/local/bin/newtmgr
-ls -l /usr/local/bin/newtmgr
-lrwxr-xr-x  1 user  staff  42 Sep 11 21:15 /usr/local/bin/newtmgr -> ../Cellar/mynewt-newtmgr/1.2.0/bin/newtmgr
 ```
 **Note:** If you previously built newtmgr from source and the output of `which newtmgr` shows "$GOPATH/bin/newtmgr", you will need to move "$GOPATH/bin"  after "/usr/local/bin" for your PATH in  ~/.bash_profile, and source ~/.bash_profile.
 
@@ -126,27 +117,10 @@ $brew unlink mynewt-newtmgr
 Install the latest unstable version of newtmgr from the master branch:
 ```no-highlight
 $brew install mynewt-newtmgr --HEAD
-==> Installing mynewt-newtmgr from runtimeco/mynewt
-==> Cloning https://github.com/apache/mynewt-newtmgr.git
-Cloning into '/Users/wanda/Library/Caches/Homebrew/mynewt-newtmgr--git'...
-remote: Counting objects: 2169, done.
-remote: Compressing objects: 100% (1752/1752), done.
-remote: Total 2169 (delta 379), reused 2042 (delta 342), pack-reused 0
-Receiving objects: 100% (2169/2169), 8.13 MiB | 5.47 MiB/s, done.
-Resolving deltas: 100% (379/379), done.
-==> Checking out branch master
-==> go get github.com/currantlabs/ble
-==> go get github.com/raff/goble
-==> go get github.com/mgutz/logxi/v1
-==> go install
-🍺  /usr/local/Cellar/mynewt-newtmgr/HEAD-2d5217f: 3 files, 17.3MB, built in 1 minute 10 seconds
 ```
 <br>
 To switch back to the latest stable release version of newtmgr, you can run:
 ```no-highlight
 $brew switch mynewt-newtmgr 1.2.0
-Cleaning /usr/local/Cellar/mynewt-newtmgr/1.2.0
-Cleaning /usr/local/Cellar/mynewt-newtmgr/HEAD-2d5217f
-1 links created for /usr/local/Cellar/mynewt-newtmgr/1.2.0
 ```
 <br>

--- a/docs/newtmgr/prev_releases.md
+++ b/docs/newtmgr/prev_releases.md
@@ -65,7 +65,7 @@ Version|Download
 
 Version|Download
 -------|--------
-1.1.0  |[newtmgr_1_1_0_windows_amd64.tar.gz](https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.1.0/newtmgr_1.1.0-1_amd64.deb)
+1.1.0  |[newtmgr_1_1_0_windows_amd64.tar.gz](https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.1.0/newtmgr_1_1_0_windows_amd64.tar.gz)
 
 <br>
 2. Extract the file:


### PR DESCRIPTION
**NOTE: This PR updates the 1.2.0 docs to make it easier to update new releases. It does not have the updates needed for the 1.3.0 release.**
- Removed note that brew bottles are created for el-capitan.
  Now we only release bottles for the latest(sierra) mac os.
- Removed output of brew commands
- Updated link for downloading debian packages manually from
debian-mynewt to binary-releases repo.
- Fixed link in previous windows releases to point to tar files instead of deb files