### PR TITLE
Added architecture to sources.list entry

### DIFF
--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -46,7 +46,7 @@ Add the repository for the binary and source packages to the `mynewt.list` apt s
 
 ```no-highlight
 $ sudo tee /etc/apt/sources.list.d/mynewt.list <<EOF
-deb https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
+deb [arch=amd64] https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 EOF
 ```
 


### PR DESCRIPTION
Using the original instructions I got the following error after running `apt-get update`:
`N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest InRelease' doesn't support architecture 'i386'`

The explanation for why this is needed is here: https://askubuntu.com/a/741411