### PR TITLE
Updated BLE Peripheral Project Service Registration Page

### DIFF
--- a/docs/os/tutorials/bleprph/bleprph-svc-reg.md
+++ b/docs/os/tutorials/bleprph/bleprph-svc-reg.md
@@ -41,10 +41,7 @@ static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
 <br>
 
 As you can see, the table is an array of service definitions (
-`struct ble_gatt_svc_def`).  This code excerpt contains a small part of the
-*GAP service*.  The GAP service exposes generic information about a device,
-such as its name and appearance.  Support for the GAP service is mandatory for
-all BLE peripherals.  Let's now consider the contents of this table in more
+`struct ble_gatt_svc_def`). Let's now consider the contents of this table in more
 detail.
 
 A service definition consists of the following fields:
@@ -58,7 +55,7 @@ A service definition consists of the following fields:
 <br>
 
 A service is little more than a container of characteristics; the
-characteristics themselves are where the real action happens.  A characteristic
+characteristics themselves are where the real action happens. A characteristic
 definition consists of the following fields:
 
 | *Field* | *Meaning* | *Notes* |
@@ -67,12 +64,12 @@ definition consists of the following fields:
 | access\_cb  | A callback function that gets executed whenever a peer device accesses this characteristic. | *For reads:* this function generates the value that gets sent back to the peer.<br>*For writes:* this function receives the written value as an argument. |
 | flags       | Indicates which operations are permitted for this characteristic.  The NimBLE stack responds negatively when a peer attempts an unsupported operation. | The full list of flags can be found under `ble_gatt_chr_flags` in [net/nimble/host/include/host/ble_gatt.h](https://github.com/apache/mynewt-core/blob/master/net/nimble/host/include/host/ble_gatt.h).|
 
-The access callback is what implements the characteristic's behavior.  Access
+The access callback is what implements the characteristic's behavior. Access
 callbacks are described in detail in the next section:
 [BLE Peripheral - Characteristic Access](bleprph-chr-access/).
 
 The service definition array and each characteristic definition array is
-terminated with an empty entry, represented with a 0.  The below code listing
+terminated with an empty entry, represented with a 0. The below code listing
 shows the last service in the array, including terminating zeros for the
 characteristic array and service array.
 
@@ -131,6 +128,9 @@ The *bleprph* app registers its services as follows:
         return rc;
     }
 ```
+
+More detailed information about the registration function can be found
+in the BLE User Guide: [ble_gatts_add_svcs](../../../network/ble/ble_hs/ble_gatts/functions/ble_gatts_add_svcs/).
 
 <br>
 

--- a/docs/os/tutorials/bleprph/bleprph-svc-reg.md
+++ b/docs/os/tutorials/bleprph/bleprph-svc-reg.md
@@ -22,20 +22,19 @@ so let's take a look at that now.  The attribute table is called
 ```c
 static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
     {
-        /*** Service: GAP. */
-        .type               = BLE_GATT_SVC_TYPE_PRIMARY,
-        .uuid128            = BLE_UUID16(BLE_GAP_SVC_UUID16),
-        .characteristics    = (struct ble_gatt_chr_def[]) { {
-            /*** Characteristic: Device Name. */
-            .uuid128            = BLE_UUID16(BLE_GAP_CHR_UUID16_DEVICE_NAME),
-            .access_cb          = gatt_svr_chr_access_gap,
-            .flags              = BLE_GATT_CHR_F_READ,
+        /*** Service: Security test. */
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = &gatt_svr_svc_sec_test_uuid.u,
+        .characteristics = (struct ble_gatt_chr_def[]) { {
+            /*** Characteristic: Random number generator. */
+            .uuid = &gatt_svr_chr_sec_test_rand_uuid.u,
+            .access_cb = gatt_svr_chr_access_sec_test,
+            .flags = BLE_GATT_CHR_F_READ,
         }, {
-            /*** Characteristic: Appearance. */
-            .uuid128            = BLE_UUID16(BLE_GAP_CHR_UUID16_APPEARANCE),
-            .access_cb          = gatt_svr_chr_access_gap,
-            .flags              = BLE_GATT_CHR_F_READ,
-        }, {
+            /*** Characteristic: Static value. */
+            .uuid = &gatt_svr_chr_sec_test_static_uuid.u,
+            .access_cb = gatt_svr_chr_access_sec_test,
+            .flags = BLE_GATT_CHR_F_READ,
     // [...]
 ```
 
@@ -79,31 +78,21 @@ characteristic array and service array.
 
 <br>
 
-```c hl_lines="26 31"
+```c hl_lines="16 21"
     {
-        /*** Alert Notification Service. */
+        /*** Service: Security test. */
         .type = BLE_GATT_SVC_TYPE_PRIMARY,
-        .uuid128 = BLE_UUID16(GATT_SVR_SVC_ALERT_UUID),
+        .uuid = &gatt_svr_svc_sec_test_uuid.u,
         .characteristics = (struct ble_gatt_chr_def[]) { {
-            .uuid128 = BLE_UUID16(GATT_SVR_CHR_SUP_NEW_ALERT_CAT_UUID),
-            .access_cb = gatt_svr_chr_access_alert,
+            /*** Characteristic: Random number generator. */
+            .uuid = &gatt_svr_chr_sec_test_rand_uuid.u,
+            .access_cb = gatt_svr_chr_access_sec_test,
             .flags = BLE_GATT_CHR_F_READ,
         }, {
-            .uuid128 = BLE_UUID16(GATT_SVR_CHR_NEW_ALERT),
-            .access_cb = gatt_svr_chr_access_alert,
-            .flags = BLE_GATT_CHR_F_NOTIFY,
-        }, {
-            .uuid128 = BLE_UUID16(GATT_SVR_CHR_SUP_UNR_ALERT_CAT_UUID),
-            .access_cb = gatt_svr_chr_access_alert,
+            /*** Characteristic: Static value. */
+            .uuid = &gatt_svr_chr_sec_test_static_uuid.u,
+            .access_cb = gatt_svr_chr_access_sec_test,
             .flags = BLE_GATT_CHR_F_READ,
-        }, {
-            .uuid128 = BLE_UUID16(GATT_SVR_CHR_UNR_ALERT_STAT_UUID),
-            .access_cb = gatt_svr_chr_access_alert,
-            .flags = BLE_GATT_CHR_F_NOTIFY,
-        }, {
-            .uuid128 = BLE_UUID16(GATT_SVR_CHR_ALERT_NOT_CTRL_PT),
-            .access_cb = gatt_svr_chr_access_alert,
-            .flags = BLE_GATT_CHR_F_WRITE,
         }, {
             0, /* No more characteristics in this service. */
         } },
@@ -152,7 +141,7 @@ It is possible to set a callback function that gets executed each time a service
 ```c
 ble_hs_cfg.gatts_register_cb = gatt_svr_register_cb;
 ```
-In the above example `gatt_svr_register_cb` is the function that will be called. 
+In the above example `gatt_svr_register_cb` is the function that will be called. This line can be found in *bleprph*'s `main.c` file
 
 More detailed information about the registration callback function can be found
 in the [BLE User Guide](../../../network/ble/ble_intro/) (TBD).


### PR DESCRIPTION
I've updated the page to use the current APIs and match with the current bleprph demo files. Please check this carefully as I'm new to Mynewt.

I think the first couple of paragraphs still need to be changed as several gatt services seem to be built into nimble rather than all listed in one gatt table like the old bleprph demo.