### PR TITLE
The NimBLE Stack Initialization page no longer exists

### DIFF
--- a/docs/os/tutorials/bleprph/bleprph-intro.md
+++ b/docs/os/tutorials/bleprph/bleprph-intro.md
@@ -19,7 +19,6 @@ familiarize yourself with the following pages:
 
 * [Create Your First Mynewt Project](../../get_started/project_create/)
 * [BLE Bare Bones Application Tutorial](../../../os/tutorials/ble_bare_bones/)
-* [NimBLE Stack Initialization](../../../network/ble/ini_stack/ble_ini_intro/)
 
 <br>
 


### PR DESCRIPTION
It appears as though this portion is now all handled via sysinit. Not 100% sure if a new link should be included to somewhere else.