### PR TITLE
Previous link was a 404, updated

### DIFF
--- a/docs/os/tutorials/bleprph/bleprph-intro.md
+++ b/docs/os/tutorials/bleprph/bleprph-intro.md
@@ -29,7 +29,7 @@ A BLE peripheral interfaces with other BLE devices by exposing *services*,
 *characteristics*, and *descriptors*.  All three of these entities are
 implemented at a lower layer via *attributes*.  If you are not familiar with
 these concepts, you will probably want to check out this
-[overview](https://developer.bluetooth.org/TechnologyOverview/Pages/GATT.aspx)
+[overview](https://www.bluetooth.com/specifications/gatt/generic-attributes-overview)
 from the Bluetooth Developer's site before proceeding.
 
 Now let's dig in to some C code.


### PR DESCRIPTION
Seems as though the bluetooth.com site has seen some changes last year. I used the wayback machine to dig up what the intended page was and found it's new location. If there are any other links to bluetooth.com documentation it wouldn't surprise me if they too are broken.