### PR TITLE
newt mfg create appears to take a version now

### DIFF
--- a/docs/newt/command_list/newt_mfg.md
+++ b/docs/newt/command_list/newt_mfg.md
@@ -90,7 +90,7 @@ $ newt create-image rb_blinky 0.0.1
 Run the `newt mfg create` command to collect all the manufacturing snapshot files.
 
 ```
-$ newt mfg create rb_blinky_rsa
+$ newt mfg create rb_blinky_rsa 0.0.1
 Creating a manufacturing image from the following files:
 <snip>
 Generated the following files:


### PR DESCRIPTION
Presumably the same version as create-image rb_blinky ?