### PR TITLE
Fix building air quality example on mynewt 1.3.0

### DIFF
--- a/docs/os/tutorials/air_quality_sensor.md
+++ b/docs/os/tutorials/air_quality_sensor.md
@@ -426,6 +426,7 @@ syscfg.vals:
 Then register your senseair command with the shell by adding the following to `libs/my_drivers/senseair/src/senseair.c`
 
 ```c
+#include <syscfg/syscfg.h>
 #include <shell/shell.h>
 #include <console/console.h>
 #include <assert.h>


### PR DESCRIPTION
This fixes a broken example due to lack of `MYNEWT_VAL(x)` definition. PS: `shell.h` already includes `<syscfg/syscfg.h>` in `master` so this change will not be required when 1.4.0 comes out (but it doesn't hurt having it anyway).