### PR TITLE
search results: disallow indexing of older doc versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,27 @@ Install the requirements:
 1. Fork the repo.
 1. Work on the `master` branch.
 1. Preview your changes using MkDocs.
-    * `mkdocs serve`
-    * visit [http://localhost:8000](http://localhost:8000)
+    - `mkdocs serve`
+    - visit [http://localhost:8000](http://localhost:8000)
 1. Submit a pull request.
 
 ## Releasing a versioned set of MyNewt documentation
 
-NOTE: When it comes time to create a static versioned set of docs from the mynewt-documentation repo for v1.4.0, these instructions will need to be modified.
+NOTE: When it comes time to create a static versioned set of docs from the
+mynewt-documentation repo for v1.4.0, these instructions will need to be
+modified.
 
-When a release of MyNewt OS and its associated tools occurs, a new version directory should be created to hold all docs pertaining to that release. The documentation in the git `master` branch of this repository always shows the latest docs under development. The following steps will create a documentation directory for a new release and make it available from the mynewt-site.
+When a release of MyNewt OS and its associated tools occurs, a new version
+directory should be created to hold all docs pertaining to that release. The
+documentation in the git `master` branch of this repository always shows the
+latest docs under development. The following steps will create a documentation
+directory for a new release and make it available from the mynewt-site.
 
 ### Merge all changes and update
 
 1. Merge pull requests to `master` on github.
 1. Switch to the master branch.
-    * `git checkout master`
+    - `git checkout master`
 1. While in master, do `git pull --rebase origin master` to pull the latest merged changes.
 
 ### Cut the new release documentation set
@@ -43,13 +49,15 @@ When a release of MyNewt OS and its associated tools occurs, a new version direc
 NOTE: Skip these steps if you are just refreshing the current documentation or site.
 
 1. Create a new _stanza_ in `mkdocs.yml` to reflect the new version.
-    * At present `master` is the `latest` version.
-    * And that should probably not change.
+    - At present `master` is the `latest` version.
+    - And that should probably not change.
 1. Add a new _stanza_ in "custom-theme/choose_doc_version.html" for the new version.
 1. Create a new directory in the versions directory for this new version.
-    * Copy the latest docs directory and mkdocs.yml file into the new version directory
-    * Set extra.version to the new version in the copied mkdocs.yml file
-    * Create a symbolic link to the customer-theme
+    - Copy the latest docs directory and mkdocs.yml file into the new version directory
+    - Set extra.version to the new version in the copied mkdocs.yml file
+    - Create a symbolic link to the customer-theme
+1. Add a _Disallow_ section to `extras/robots.txt` for the new version so that
+   these documents do not appear in search results before the latest docs.
 1. Commit these changes.
 
 ### Build
@@ -75,7 +83,7 @@ using known versions of the build tools.
 
 ## Links to Documentation
 
-For the deployed site a version prefix is added to the URL for each mkdocs page. When developing there is no version prefix. If you want to link from a _site page_ to a _documentation page_ you should prefix the URL with */DOCSLINK/* so that the user is taken to the correct location when browsing in production.
+For the deployed site a version prefix is added to the URL for each mkdocs page. When developing there is no version prefix. If you want to link from a _site page_ to a _documentation page_ you should prefix the URL with _/DOCSLINK/_ so that the user is taken to the correct location when browsing in production.
 
 ## Link Checking
 

--- a/extras/robots.txt
+++ b/extras/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /v0_9_0/
+Disallow: /v1_0_0/
+Disallow: /v1_1_0/
+Disallow: /v1_2_0/
+Disallow: /v1_3_0/
+Disallow: /v1_4_0/


### PR DESCRIPTION
So that they do not appear in search results before the latest docs.

Fixes #473 