### PR TITLE
Fix nav link normalization for older releases

### DIFF
--- a/custom-theme/child_url.html
+++ b/custom-theme/child_url.html
@@ -1,5 +1,5 @@
 {% if child.url %}
-  {{ child.url }}
+  {{ child.url|url }}
 {% else %}
   {% set child=child.children[0] %}
   {% include "child_url.html" %}

--- a/custom-theme/choose_doc_version.html
+++ b/custom-theme/choose_doc_version.html
@@ -8,7 +8,7 @@
   <option value="/v1_4_0/" {% if config.extra.version=="v1_4_0" %}selected="selected" {% endif %}>
     Version: 1.4.0
   </option>
-  <option value="/v1_3_0/" {% if config.extra.version=="v1_3_0" %}selected="selected" {% endif %}>
+  <option value="/v1_3_0/os/introduction" {% if config.extra.version=="v1_3_0" %}selected="selected" {% endif %}>
     Version: 1.3.0
   </option>
   <option value="/v1_2_0/os/introduction" {% if config.extra.version=="v1_2_0" %}selected="selected" {% endif %}>

--- a/custom-theme/nested_toc.html
+++ b/custom-theme/nested_toc.html
@@ -1,7 +1,7 @@
 {% if nav_item.children %}
   {% set child=nav_item.children[0] %}
   {% if child.title == "toc" %}
-    <li {% if child.active %}class="active"{% endif %}><a href="{{ child.url }}">{{ nav_item.title }}</a>
+    <li {% if child.active %}class="active"{% endif %}><a href="{{ child.url|url }}">{{ nav_item.title }}</a>
   {% else %}
     <li><a href="{% include "child_url.html" %}">{{ nav_item.title }}</a>
   {% endif %}
@@ -16,7 +16,7 @@
   {% endif %}
     </li>
 {% else %}
-    <li {% if nav_item.active %}class="active"{% endif %}>
-      <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-    </li>
+  <li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
+  </li>
 {% endif %}


### PR DESCRIPTION
Just to clarify this, if someone goes today to https://mynewt.apache.org and navigates to a release from 1.3.0 and below, and starts using the left nav to choose pages to visit, most of those links are broken (404) because they are not normalized to remove the prepending uri. This fixes it by calling the url macro (see https://www.mkdocs.org/user-guide/custom-themes/#url).