### PR TITLE
Add slack url to global config

### DIFF
--- a/custom-theme/community.html
+++ b/custom-theme/community.html
@@ -19,7 +19,7 @@
                     <p text-center><a href="mailto:dev-unsubscribe@mynewt.apache.org">Unsubscribe</a></p>
                   <p> <a href="http://mail-archives.apache.org/mod_mbox/mynewt-dev/">Mail archives</a> </p>
                   <p> Find us on Slack:</p>
-                  <p> <a href="https://join.slack.com/t/mynewt/shared_invite/enQtNjA1MTg0NzgyNzg3LTZiYzgxNDQ3NmQ5ZWFkMTY4MjNjYTNmNGJjMDhiMmZiMWFjNDdkMzBlNzZjOWY0YzljYTBhYTg1YmRjYzljZDg"><img src="https://www.countit.com/images/add_to_slack.png" alt="Slack Icon" title="Join our Slack Community" /></a></p>
+                  <p> <a href="{{ config.extra.slack_url }}"><img src="https://www.countit.com/images/add_to_slack.png" alt="Slack Icon" title="Join our Slack Community" /></a></p>
                 </div>
         </div>
         <div class="col-md-4 mailing-list">

--- a/custom-theme/footer.html
+++ b/custom-theme/footer.html
@@ -8,11 +8,13 @@
         <div class="logos">
             <img src="/img/asf_logo_wide_small.png" alt="Apache" title="Apache">
             <small class="footnote">
-            Apache Mynewt, Mynewt, Apache, the Apache feather logo, and the Apache Mynewt project logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and other countries.
+                Apache Mynewt, Mynewt, Apache, the Apache feather logo, and the Apache Mynewt
+                project logo are either registered trademarks or trademarks of the Apache
+                Software Foundation in the United States and other countries.
             </small>
-             <a href="https://join.slack.com/t/mynewt/shared_invite/enQtNjA1MTg0NzgyNzg3LTZiYzgxNDQ3NmQ5ZWFkMTY4MjNjYTNmNGJjMDhiMmZiMWFjNDdkMzBlNzZjOWY0YzljYTBhYTg1YmRjYzljZDg">
+            <a href="{{ config.extra.slack_url }}">
                 <img src="/img/add_to_slack.png" alt="Slack Icon" title="Join our Slack Community" />
-             </a>
+            </a>
         </div>
     </div>
 </footer>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,8 @@ extra:
             location: "Hilton Portland Downtown, Portland, OR, USA"
             date: "12-14 March, 2018"
 
+    slack_url: "https://join.slack.com/t/mynewt/shared_invite/enQtNjA1MTg0NzgyNzg3LTZiYzgxNDQ3NmQ5ZWFkMTY4MjNjYTNmNGJjMDhiMmZiMWFjNDdkMzBlNzZjOWY0YzljYTBhYTg1YmRjYzljZDg"
+
 copyright: "Apache Mynewt is available under Apache License, version 2.0."
 
 google_analytics: ["UA-72162311-1", "auto"]


### PR DESCRIPTION
This adds the slack URL to the global config, so no copy/paste URLs are distributed across the template files.