### PR TITLE
Update landing BLE link to network page

### DIFF
--- a/custom-theme/landing.html
+++ b/custom-theme/landing.html
@@ -15,7 +15,7 @@
                   <li> Full stack, host only, or controller only - your choice </li>
                   <li> Maximum throughput of 2Mbps </li>
                   <li> 32+ concurrent connections, multiple connections in simulatenous central and peripheral roles </li>
-                  <li> <a href="pages/ble/">More on NimBLE...</a> </li>
+                  <li> <a href="latest/network/">More on NimBLE...</a> </li>
                 </ul>
               <li> LoRa PHY and LoRaWAN support </li>
                 <ul>


### PR DESCRIPTION
Fix link that goes to empty page.

Fixes https://github.com/apache/mynewt-core/issues/2397