### PR TITLE
Update download page with comments from announce list moderator

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -1,17 +1,47 @@
 ## Latest Apache Mynewt OS Release
 
+You can verify your download by following these [procedures](https://www.apache.org/info/verification.html) and using
+these [KEYS](https://downloads.apache.org/mynewt/KEYS).
+
 ### Latest Apache Mynewt Core OS Release
 
 *   Release Version: Apache Mynewt 1.9.0
 *   Release Date: April 7, 2021
 *   [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.9.0)
-*   [Release Download](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/)
- *  [core](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.8.0/apache-mynewt-core-1.9.0.tgz)
-    [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-core-1.9.0.tgz.asc)
-    [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-1.9.0.tgz.sha512)
- *   [newt](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-1.9.0.tgz)
-    [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-1.9.0.tgz.asc)
-    [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-1.9.0.tgz.sha512)
+*   Source downloads:
+    - Mynewt Core OS: [apache-mynewt-core-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-core-1.9.0.tgz)
+      [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-core-1.9.0.tgz.asc)
+      [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-core-1.9.0.tgz.sha512)
+    - Mynewt Blinky template application: [apache-mynewt-blinky-1.9.0.tgz  ](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-blinky-1.9.0.tgz)
+      [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-blinky-1.9.0.tgz.asc)
+      [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-blinky-1.9.0.tgz.sha512)
+    - Mynewt build and package management tool (newt): [apache-mynewt-newt-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-1.9.0.tgz)
+      [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-1.9.0.tgz.asc)
+      [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-1.9.0.tgz.sha512)
+    - Mynewt Manager tool (newtmgr): [apache-mynewt-newmgr-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newmgr-1.9.0.tgz)
+      [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newmgr-1.9.0.tgz.asc)
+      [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newmgr-1.9.0.tgz.sha512) [Note typo in tarball filename!]
+*   Binary downloads:
+    - Mynewt build and package management tool (newt):
+        - Linux 64bit: [apache-mynewt-newt-bin-linux-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-linux-1.9.0.tgz)
+          [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-linux-1.9.0.tgz.asc)
+          [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-linux-1.9.0.tgz.sha512)
+        - MacOS 64bit: [apache-mynewt-newt-bin-osx-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-osx-1.9.0.tgz)
+          [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-osx-1.9.0.tgz.asc)
+          [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-osx-1.9.0.tgz.sha512)
+        - Windows 64bit: [apache-mynewt-newt-bin-windows-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-windows-1.9.0.tgz)
+          [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-windows-1.9.0.tgz.asc)
+          [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newt-bin-windows-1.9.0.tgz.sha512)
+    - Mynewt Manager tool (newtmgr):
+        - Linux 64bit: [apache-mynewt-newtmgr-bin-linux-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-linux-1.9.0.tgz)
+          [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-linux-1.9.0.tgz.asc)
+          [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-linux-1.9.0.tgz.sha512)
+        - MacOS 64bit: [apache-mynewt-newtmgr-bin-osx-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-osx-1.9.0.tgz)
+          [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-osx-1.9.0.tgz.asc)
+          [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-osx-1.9.0.tgz.sha512)
+        - Windows 64bit: [apache-mynewt-newtmgr-bin-windows-1.9.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-windows-1.9.0.tgz)
+          [[PGP]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-windows-1.9.0.tgz.asc)
+          [[SHA512]](https://www.apache.org/dist/mynewt/apache-mynewt-1.9.0/apache-mynewt-newtmgr-bin-windows-1.9.0.tgz.sha512)
 
 ### Latest Apache Mynewt NimBLE (Bluetooth Stack) Release
 
@@ -20,9 +50,10 @@ Mynewt's Bluetooth stack is now a separate release with a porting layer that all
 *   Release Version: Apache NimBLE 1.4.0
 *   Release Date: April 7, 2021
 *   [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-NimBLE-1.4.0)
-*   [Release Download](https://www.apache.org/dyn/closer.lua/mynewt/apache-nimble-1.4.0/apache-mynewt-nimble-1.4.0.tgz)
-    [[PGP]](https://www.apache.org/dist/mynewt/apache-nimble-1.4.0/apache-mynewt-nimble-1.4.0.tgz.asc)
-    [[SHA512]](https://www.apache.org/dist/mynewt/apache-nimble-1.4.0/apache-mynewt-nimble-1.4.0.tgz.sha512)
+*   Source downloads:
+    - [apache-mynewt-nimble-1.4.0.tgz](https://www.apache.org/dyn/closer.lua/mynewt/apache-nimble-1.4.0/apache-mynewt-nimble-1.4.0.tgz)
+      [[PGP]](https://www.apache.org/dist/mynewt/apache-nimble-1.4.0/apache-mynewt-nimble-1.4.0.tgz.asc)
+      [[SHA512]](https://www.apache.org/dist/mynewt/apache-nimble-1.4.0/apache-mynewt-nimble-1.4.0.tgz.sha512)
 
 #### Fresh install
 
@@ -38,28 +69,6 @@ If you have already installed the Newt tool and started a project that installed
 $ newt upgrade
 ```
 
-### Code in development
-
-While the use of one of the official releases listed above is generally recommended, you may be interested in seeing work in progress.
-
-The most recent code that is fairly stable over the full OS resides in the `master` branch of the Mynewt git repository. You may view or fork the repositories for Mynewt OS and Newt Tool from the Apache mirror on github.com.
-
-*   [Apache Mynewt OS mirror on github.com](https://github.com/apache/incubator-mynewt-core/tree/master)
-*   [Apache Newt Tool mirror on github.com](https://github.com/apache/incubator-mynewt-newt/tree/master)
-
-The most recent code to support a major feature (e.g. Bluetooth 5) can be found in a long-lived feature branch dedicated to that feature (bluetooth5, in the example for Bluetooth 5) and not the master. If you are interested in seeing the latest code for that feature, you can clone the desired branch using git:
-
-```
-$ git clone git://github.com/apache/incubator-mynewt-core.git -b <feature-branch-name>
-$ git clone git://github.com/apache/incubator-mynewt-newt.git -b <feature-branch-name>
-```
-
-<br>
-
-For general information on using Git at Apache, go to https://git-wip-us.apache.org.
-
-<br>
-
 ### Prior Releases
 
 #### Apache Mynewt Core
@@ -72,20 +81,20 @@ For general information on using Git at Apache, go to https://git-wip-us.apache.
 *   Apache Mynewt 1.0.0-incubating, [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.0.0-incubating), [Release Archive](https://archive.apache.org/dist/incubator/mynewt/apache-mynewt-1.0.0-incubating/)
 *   Apache Mynewt 1.1.0, [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.1.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.1.0/)
 *   Apache Mynewt 1.2.0, [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.2.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.2.0/)
-*   Apache Mynewt 1.3.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.3.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.3.0)
-*   Apache Mynewt 1.4.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.4.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.4.0)
-*   Apache Mynewt 1.4.1 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.4.1), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.4.1)
-*   Apache Mynewt 1.5.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.5.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.5.0)
-*   Apache Mynewt 1.6.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.6.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.6.0)
-*   Apache Mynewt 1.7.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.7.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.7.0)
-*   Apache Mynewt 1.8.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.8.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-mynewt-1.8.0)
+*   Apache Mynewt 1.3.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.3.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.3.0)
+*   Apache Mynewt 1.4.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.4.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.4.0)
+*   Apache Mynewt 1.4.1 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.4.1), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.4.1)
+*   Apache Mynewt 1.5.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.5.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.5.0)
+*   Apache Mynewt 1.6.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.6.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.6.0)
+*   Apache Mynewt 1.7.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.7.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.7.0)
+*   Apache Mynewt 1.8.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.8.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-mynewt-1.8.0)
 
 #### Apache Mynewt NimBLE (Bluetooth Stack)
 
-*   Apache NimBLE 1.0.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.4.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-nimble-1.0.0)
-*   Apache NimBLE 1.1.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-NimBLE-1.1.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-nimble-1.1.0)
-*   Apache NimBLE 1.2.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-NimBLE-1.2.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-nimble-1.2.0)
-*   Apache NimBLE 1.3.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-NimBLE-1.3.0), [Release Archive](https://www.apache.org/dyn/closer.lua/mynewt/apache-nimble-1.3.0)
+*   Apache NimBLE 1.0.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-1.4.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-nimble-1.0.0)
+*   Apache NimBLE 1.1.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-NimBLE-1.1.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-nimble-1.1.0)
+*   Apache NimBLE 1.2.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-NimBLE-1.2.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-nimble-1.2.0)
+*   Apache NimBLE 1.3.0 [Release Notes](https://cwiki.apache.org/confluence/display/MYNEWT/RN-NimBLE-1.3.0), [Release Archive](https://archive.apache.org/dist/mynewt/apache-nimble-1.3.0)
 
 <br>
 <br>


### PR DESCRIPTION
Following issues were fixed:
- there is no link to the KEYS file at
  https://downloads.apache.org/mynewt/KEYS
- there is no mention of the need to verify downloads, nor
   information on how to do so using the KEYS and sigs or hashes
- the core 1.9.0 link has a typo, so the link does not work
- it's not clear what the difference is between the core and newt
  downloads. Are they both needed?
- the download page must not link to non-released software such as code
  under development. Such links should be reserved for pages intended
  for developers only.
- the download page must not link directly to mirror directories, as these
  don't carry the sigs and hashes:
  -- the Release Download link for MyNewt core 1.9.0 should be removed
  -- Added direct links to source and binary releases
- fixed old releases links to point to archive server