### PR TITLE
mkdocs: Disable `google_analytics` in site config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,5 +110,3 @@ extra:
     slack_url: "https://join.slack.com/t/mynewt/shared_invite/enQtNjA1MTg0NzgyNzg3LTcyMmZiOGQzOGMxM2U4ODFmMTIwNjNmYTE5Y2UwYjQwZWIxNTE0MTUzY2JmMTEzOWFjYWZkNGM0YmM4MzAxNWQ"
 
 copyright: "Apache Mynewt is available under Apache License, version 2.0."
-
-google_analytics: ["UA-72162311-1", "auto"]


### PR DESCRIPTION
Removes Google Analytics from the site to align with [ASF Data Privacy Policy](https://privacy.apache.org/faq/committers.html).

