### PR TITLE
Remove Google Analytics from mynewt Wesbiste

### DIFF
--- a/custom-theme/main.html
+++ b/custom-theme/main.html
@@ -30,26 +30,6 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.google_analytics %}
-            <script>
-            (function(i, s, o, g, r, a, m) {
-    i["GoogleAnalyticsObject"] = r;
-    (i[r] =
-        i[r] ||
-        function() {
-            (i[r].q = i[r].q || []).push(arguments);
-        }),
-        (i[r].l = 1 * new Date());
-    (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m);
-})(window, document, "script", "//www.google-analytics.com/analytics.js", "ga");
-
-ga("create", "{{ config.google_analytics[0] }}", "{{ config.google_analytics[1] }}");
-ga("send", "pageview");
-</script>
-        {% endif %}
     </head>
 
 {% if page.title != None %}

--- a/versions/v0_9_0/mkdocs.yml
+++ b/versions/v0_9_0/mkdocs.yml
@@ -409,4 +409,3 @@ extra:
 
 copyright: 'Apache Mynewt (incubating) is available under Apache License, version 2.0.' 
 
-google_analytics: ['UA-72162311-1', 'auto']

--- a/versions/v1_0_0/mkdocs.yml
+++ b/versions/v1_0_0/mkdocs.yml
@@ -600,4 +600,3 @@ extra:
 
 copyright: 'Apache Mynewt (incubating) is available under Apache License, version 2.0.' 
 
-google_analytics: ['UA-72162311-1', 'auto']

--- a/versions/v1_1_0/mkdocs.yml
+++ b/versions/v1_1_0/mkdocs.yml
@@ -650,4 +650,3 @@ extra:
 
 copyright: 'Apache Mynewt is available under Apache License, version 2.0.'
 
-google_analytics: ['UA-72162311-1', 'auto']

--- a/versions/v1_2_0/mkdocs.yml
+++ b/versions/v1_2_0/mkdocs.yml
@@ -657,4 +657,3 @@ extra:
 
 copyright: 'Apache Mynewt is available under Apache License, version 2.0.'
 
-google_analytics: ['UA-72162311-1', 'auto']

--- a/versions/v1_3_0/mkdocs.yml
+++ b/versions/v1_3_0/mkdocs.yml
@@ -655,4 +655,3 @@ extra:
 
 copyright: 'Apache Mynewt is available under Apache License, version 2.0.'
 
-google_analytics: ['UA-72162311-1', 'auto']


### PR DESCRIPTION
**Remove Google Analytics from mynewt Wesbiste**

The mynewt website is using Google Analytics on 2,239 pages in versions 0.9, 1.0, 1.1, 1.2 & 1.3 of its documentation. The ASF Privacy Policy[1][2] does not permit the use of Google Analytics on any ASF websites.

Please see https://github.com/apache/mynewt-core/issues/3366