### PR TITLE
custom-theme: talks: add yt videos hyperlinks

### DIFF
--- a/custom-theme/talks.html
+++ b/custom-theme/talks.html
@@ -31,7 +31,9 @@
   </div>
 
   <div class="col-xs-12 col-md-6">
-    <h3>Apache Mynewt Overview</h3>
+    <a href="https://www.youtube-nocookie.com/embed/4xRbGMDcMu8?si=1AiPorODLysJ0E1l" target="_blank" style="text-decoration: none;">
+      <h3>Apache Mynewt Overview</h3>
+    </a>
     </br>
     @OpenIoT Summit, Berlin, Germany, October 2016
     </br>
@@ -45,7 +47,9 @@
 
 <div class="row">
   <div class="col-xs-12 col-md-6">
-    <h3>MyNewt technical Overview</h3>
+    <a href="https://www.youtube-nocookie.com/embed/5KhnjE7zYx4?si=FOFm6vAd3n3pMMdd" target="_blank" style="text-decoration: none;">
+      <h3>MyNewt technical Overview</h3>
+    </a>
     <br>
     @Linaro Connect, Las Vegas, September 2016
     <br>
@@ -75,7 +79,9 @@
   </div>
 
   <div class="col-xs-12 col-md-6">
-    <h3>Apache Mynewt: The Next Great Open Source OS for 32 Bit MCUs Coming to a RISC-V</h3>
+    <a href="https://www.youtube-nocookie.com/embed/RsDqH5FZ-bo?si=trecTDB1m9xHuvQ1" target="_blank" style="text-decoration: none;">
+      <h3>Apache Mynewt: The Next Great Open Source OS for 32 Bit MCUs Coming to a RISC-V</h3>
+    </a>  
     </br>
     @RISC-V Workshop, July 2016
     </br>


### PR DESCRIPTION
This is temporary solution to issue with properly embedding Youtube videos in Talks section.