### PR TITLE
Update workflow file

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   deploy:
     name: Deploy Site
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Change ubuntu version from 20.04 to 22.04 as Ubuntu 20.04 LTS runner has been removed on 2025-04-15.
See deprecation notice https://github.com/actions/runner-images/issues/11101