### PR TITLE
Remove externally loaded materials

### DIFF
--- a/custom-theme/community.html
+++ b/custom-theme/community.html
@@ -19,7 +19,7 @@
                     <p text-center><a href="mailto:dev-unsubscribe@mynewt.apache.org">Unsubscribe</a></p>
                   <p> <a href="https://mail-archives.apache.org/mod_mbox/mynewt-dev/" target="_blank">Mail archives</a> </p>
                   <p> Find us on Slack:</p>
-                  <p> <a href="{{ config.extra.slack_url }}"><img src="https://www.countit.com/images/add_to_slack.png" alt="Slack Icon" title="Join our Slack Community" /></a></p>
+                  <p> <a href="{{ config.extra.slack_url }}"><img src="/img/add_to_slack.png" alt="Slack Icon" title="Join our Slack Community" /></a></p>
                 </div>
         </div>
         <div class="col-md-4 mailing-list">
@@ -56,11 +56,11 @@
 
                 <p> If you want to browse the code, <a href="https://github.com/apache/mynewt-core">Mynewt Core Repo</a> is the best place to start.
 
-                <p> If you wish to contribute code, a quick look at the <a href="https://cwiki.apache.org/confluence/display/MYNEWT/Contributing+to+Apache+Mynewt"> recommended steps </a> should help.  
+                <p> If you wish to contribute code, a quick look at the <a href="https://cwiki.apache.org/confluence/display/MYNEWT/Contributing+to+Apache+Mynewt"> recommended steps </a> should help.
 
                 <h3>Bug Submission and Issue Tracking</h3>
                 <p> Issues, features, improvements, and wish-lists are now tracked on the <a href="https://github.com/apache/mynewt-core/issues">Mynewt Core Github Repo</a>. New issues will be marked with the appropriate label by a committer who will review them. </p>
-              
+
                 <p> If you are a contributor and wish to work on a change, it's always a good idea to introduce the change in the dev@ mailing list before submitting a pull request into the GitHub mirror for your change. </p>
 <br>
 

--- a/custom-theme/main.html
+++ b/custom-theme/main.html
@@ -18,8 +18,7 @@
         <link href="{{ base_url }}/css/base.css" rel="stylesheet">
         <link href="{{ base_url }}/css/custom.css" rel="stylesheet">
         <link href="{{ base_url }}/css/v2.css" rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+        <link href="{{ base_url }}/css/font-awesome-4.0.3.css" rel="stylesheet">
         {%- for path in config.extra_css %}
         <link href="{{ path }}" rel="stylesheet">
         {%- endfor %}


### PR DESCRIPTION
- Get rid of externally loaded fonts. It is recommended in ASF Security Policy not to use any external resources. "ASF projects don’t have any reason to load Google Fonts from Google servers". Please see https://privacy.apache.org/faq/committers.html

- Use hosted Slack Icon file. instead of externally loaded. The Icon wasn't properly displayed.
 
Please see **https://whimsy.apache.org/site/project/mynewt** for mynewt website checks