### PR TITLE
ci: use python 3.8

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -35,7 +35,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: master
-
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
       - name: Install Dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
Use python 3.8 in deploy-site workflow