### PR TITLE
Update requirements and use python 3.13 in workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -37,7 +37,7 @@ jobs:
           ref: master
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+            python-version: '3.13'
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs==1.1.2
-sh==1.14.1
-Sphinx==3.5.4
-recommonmark==0.6.0
-breathe==4.28.0
-jinja2==3.0.3
+mkdocs==1.6.1
+sh==2.2.2
+Sphinx==8.2.3
+recommonmark==0.7.1
+breathe==4.36.0
+jinja2==3.1.6


### PR DESCRIPTION
- workflow will now use python 3.13
- use latest versions of all tools and plugins

Upgrading sphinx requires https://github.com/apache/mynewt-documentation/pull/128 to be merged